### PR TITLE
Add scalaz bintray as resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
 scalaVersion := "2.11.4"
 
 crossScalaVersions := Seq("2.10.4", "2.11.4")
-
+resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 homepage := Some(url("https://github.com/guardian/scala-cloudwatch-metrics"))
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 


### PR DESCRIPTION
Hi, 

I couldn't build this locally because of 

```
[info] Resolving org.scala-lang#scalap;2.11.4 ...
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: org.scalaz.stream#scalaz-stream_2.11;0.6: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn]
[warn] 	Note: Unresolved dependencies path:
[warn] 		org.scalaz.stream:scalaz-stream_2.11:0.6 (/Users/willbell/repos/scala-cloudwatch-metrics/build.sbt#L45-52)
[warn] 		  +- com.gu:scala-cloudwatch-metrics_2.11:1.0-b2090d49e3eda7c9a9d63effec27ff69369b33d2
```

Similar problems I found on the web suggest adding bintray as a resolver and this seems to have fixed my problem.

Thanks

William